### PR TITLE
Refactor the error management to use typed-exception's AsyncV

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "purescript-simple-json": "^4.3.0",
     "purescript-strings": "^4.0.1",
     "purescript-node-fs": "^5.0.0",
-    "purescript-affjax": "^7.0.0"
+    "purescript-affjax": "^7.0.0",
+    "purescript-checked-exceptions": "^2.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/src/Control/Async.purs
+++ b/src/Control/Async.purs
@@ -1,37 +1,105 @@
 module Control.Async
   ( Async
-  , ifItWorked
-  , withError
+  , mapExceptT'
+  , throwErrorV
+  , runAsync
+  , exception
+  , Exception
+  , errorMessage
+  , ErrorMessage
   )
-   where
+where
 
 import Prelude
 
-import Effect (Effect)
-import Control.Monad.Cont.Trans (ContT)
-import Data.Either (Either(..))
+import Control.Monad.Cont.Trans (ContT, runContT)
+import Control.Monad.Error.Class (class MonadThrow)
+import Control.Monad.Except (ExceptT, runExceptT)
+import Control.Monad.Except as ExceptT
+import Control.Monad.Except.Checked (ExceptV)
 import Data.Bifunctor (lmap)
+import Data.Either (Either)
+import Data.Variant (SProxy(..), Variant, inj)
+import Effect (Effect)
+import Effect.Exception (Error)
+import Type.Row (RowApply)
 
--- Async eff a = (Either Error a -> Eff eff Unit) -> Eff eff Unit
-type Async = ContT Unit Effect
+-- | Represents an asynchronous computation that can fail with an error defined in a `Variant ρ`
+-- | or succeed yielding a value of type `a`.
+-- |
+-- | The variable `ρ` (Greek letter Rho) is a [Row Type](https://github.com/purescript/documentation/blob/master/language/Types.md#rows),
+-- | and it is used with ExceptV, from the package [checked-exceptions](https://github.com/natefaubion/purescript-checked-exceptions),
+-- | to model Extensible errors.
+-- |
+-- | Instead of defining errors with data which is a closed Set (it can't be extended)
+-- | ```purescript
+-- | data ApiError
+-- |   = RequestError Error
+-- |   | InvalidCredentials
+-- |   | InvalidResponse MultipleErrors
+-- | ```
+-- |
+-- | We can define our errors as an extensible Set, so we can use our computation to generate other results
+-- | and in the process add, or resolve errors from the Set.
+-- | ```purescript
+-- | type ApiError ρ = (RequestError ⋃ InvalidCredentials ⋃ InvalidResponse ⋃ ρ)
+-- | ```
+type Async ρ a =  ExceptV ρ (ContT Unit Effect) a
 
+-- | Used to join error types together, for example (ErrorMessage ⋃ Exception ⋃ ρ)
+-- |
+-- | **unicode** `option+22C3`
+infixr 0 type RowApply as ⋃
 
--- Helper functions to work with Async (Either e a)
+-- | Empty Set
+-- |
+-- | **unicode** `option+00D8`
+type Ø = ()
+-------------------------------------------------------------------------------
 
--- Helps with do notation, runs the async f if the previous result was successful
--- kind like then from promises
-ifItWorked :: forall a b e
-  .  Either e a
-  -> (a -> Async (Either e b))
-  -> Async (Either e b)
-ifItWorked maybeA f =
-  case maybeA of
-    Left err -> pure $ Left err
-    Right c  -> f c
+-- | Runs an asynchronous computation
+runAsync :: ∀ a e. Async e a -> (Either (Variant e) a -> Effect Unit) -> Effect Unit
+runAsync =  runContT <<< runExceptT
 
+-----
 
-withError :: forall e e' a
-  .  Async (Either e a)
+-- | Throws an error, restricting the error type to a Variant
+throwErrorV :: ∀ a m e. MonadThrow (Variant e) m => Variant e -> m a
+throwErrorV = ExceptT.throwError
+
+-----
+
+-- | Maps the error of a Monad Stack that includes the ExceptT Transformer.
+-- | It's a helper around mapExceptT, to only concentrate about mapping the error.
+-- | I'm not sure if this function should reside here.
+mapExceptT' :: forall e e' a m
+  . Functor m
+  =>  ExceptT e m a
   -> (e -> e')
-  -> Async (Either e' a)
-withError a fe = lmap fe <$> a
+  -> ExceptT e' m a
+mapExceptT' stack fe = ExceptT.mapExceptT map' stack where
+  map' :: (m (Either e a) -> m (Either e' a))
+  map' m = lmap fe <$> m
+
+
+-------------------------------------------------------------------------------
+-- Common Errors
+
+-- | An ErrorMessage is a simple string error.
+-- | It should be used whenever you want to fail with a simple reason explaining
+-- | the failure.
+type ErrorMessage ρ = (message ∷ String | ρ)
+
+-- | Error constructor
+errorMessage :: ∀ ρ. String -> Variant (ErrorMessage ρ)
+errorMessage message = inj (SProxy :: SProxy "message") message
+
+-----
+
+-- | An Exception is a JavaScript Error object, which you can then message or see the Runtime stack
+type Exception ρ = (exception ∷ Error | ρ)
+
+-- | Error constructor
+exception :: ∀ ρ. Error -> Variant (Exception ρ)
+exception e = inj (SProxy :: SProxy "exception") e
+

--- a/src/Control/Async.purs
+++ b/src/Control/Async.purs
@@ -72,7 +72,7 @@ throwErrorV = ExceptT.throwError
 -- | Maps the error of a Monad Stack that includes the ExceptT Transformer.
 -- | It's a helper around mapExceptT, to only concentrate about mapping the error.
 -- | I'm not sure if this function should reside here.
-mapExceptT' :: forall e e' a m
+mapExceptT' :: ∀ e e' a m
   . Functor m
   =>  ExceptT e m a
   -> (e -> e')

--- a/src/Control/File.purs
+++ b/src/Control/File.purs
@@ -2,11 +2,13 @@ module Control.File
   ( readJsonFile
   , readFile
   , readTextFile
+  , _readFileError
+  , _readFileJsonParseError
   , ReadJsonFileError
   , ReadFileError
-  , ReadFileErrorImpl
+  , ReadFileErrorImpl (..)
   , JsonParseError
-  , JsonParseErrorImpl
+  , JsonParseErrorImpl (..)
   )
 where
 
@@ -14,21 +16,23 @@ import Prelude
 
 import Control.Async (Async, mapExceptT')
 import Control.Monad.Cont.Trans (ContT(..))
-import Data.Bifunctor (lmap)
 import Control.Monad.Except (ExceptT(..), except)
+import Data.Bifunctor (lmap)
+import Data.Either (Either)
 import Data.Explain (class Explain, explain)
 import Data.Either (Either)
 import Data.JSON.ParseForeign (class ParseForeign, readJSON)
 import Data.List.Types (NonEmptyList)
 import Data.Variant (SProxy(..), Variant, inj)
 import Effect.Class (liftEffect)
-import Effect.Exception (Error)
+import Effect.Exception (Error, message)
 import Foreign (ForeignError)
 import Node.Buffer (Buffer, toString)
 import Node.Encoding (Encoding(..))
 import Node.FS.Async as FS
+import Node.Path (FilePath)
+import Type.Data.Boolean (kind Boolean)
 import Type.Row (RowApply)
-
 infixr 0 type RowApply as ⋃
 
 -------------------------------------------------------------------------------
@@ -46,6 +50,7 @@ readTextFile ::
 readTextFile path = (readFile path) >>= toString' where
   toString' :: forall e. Buffer -> Async e String
   toString' buff = liftEffect $ toString UTF8 buff
+
 
 
 -- -- TODO: Thinking of putting this into a ForeignHelper
@@ -82,6 +87,9 @@ readJsonFile path = do
 -- | Thrown when a readFile was unsuccesful
 type ReadFileError ρ = (readFileError ∷ ReadFileErrorImpl | ρ)
 
+_readFileError :: SProxy "readFileError"
+_readFileError = SProxy
+
 newtype ReadFileErrorImpl
   = ReadFileErrorImpl
     { path  :: String
@@ -89,24 +97,29 @@ newtype ReadFileErrorImpl
     }
 
 instance explainReadFileError :: Explain ReadFileErrorImpl where
-  explain (ReadFileErrorImpl {path, error}) = "Could not read file \"" <> path <> "\""
+  explain (ReadFileErrorImpl {path, error}) = "Could not read file \"" <> path <> "\"" <> message error
 
 readFileError :: ∀ ρ. String -> Error -> Variant (ReadFileError ρ)
-readFileError path error = inj (SProxy :: SProxy "readFileError") (ReadFileErrorImpl { path, error })
+readFileError path error = inj _readFileError (ReadFileErrorImpl { path, error })
+
+---------------------------------------
 
 -- | Thrown when parsing a file as JSON
 type JsonParseError ρ = (readFileJsonParseError ∷ JsonParseErrorImpl | ρ)
 
+-- TODO: unify into either jsonParseError or readFileJsonParseError
+_readFileJsonParseError :: SProxy "readFileJsonParseError"
+_readFileJsonParseError = SProxy
+
 newtype JsonParseErrorImpl
   = JsonParseErrorImpl
-    { path  :: String
+    { path  :: FilePath
     , error :: NonEmptyList ForeignError
     }
 
 instance explainJsonParseError :: Explain JsonParseErrorImpl where
   explain (JsonParseErrorImpl {path, error}) = "There was a problem parsing the json file " <> show path <> ":" <> explain error
 
-jsonParseError :: ∀ ρ. String -> NonEmptyList ForeignError -> Variant (JsonParseError ρ)
-jsonParseError path error = inj (SProxy :: SProxy "readFileJsonParseError") (JsonParseErrorImpl { path, error })
-
+jsonParseError :: ∀ ρ. FilePath -> NonEmptyList ForeignError -> Variant (JsonParseError ρ)
+jsonParseError path error = inj _readFileJsonParseError (JsonParseErrorImpl { path, error })
 

--- a/src/Control/File.purs
+++ b/src/Control/File.purs
@@ -20,7 +20,6 @@ import Control.Monad.Except (ExceptT(..), except)
 import Data.Bifunctor (lmap)
 import Data.Either (Either)
 import Data.Explain (class Explain, explain)
-import Data.Either (Either)
 import Data.JSON.ParseForeign (class ParseForeign, readJSON)
 import Data.List.Types (NonEmptyList)
 import Data.Variant (SProxy(..), Variant, inj)
@@ -48,7 +47,7 @@ readTextFile ::
   .  String
   -> Async (ReadFileError ρ) String
 readTextFile path = (readFile path) >>= toString' where
-  toString' :: forall e. Buffer -> Async e String
+  toString' :: ∀ e. Buffer -> Async e String
   toString' buff = liftEffect $ toString UTF8 buff
 
 

--- a/src/Data/Explain.purs
+++ b/src/Data/Explain.purs
@@ -25,7 +25,7 @@ instance explainString :: Explain String where
   explain str = str
 
 -------------------------------------------------------------------------------
-explainFoldable :: forall f a. Foldable f => Explain a => f a -> String
+explainFoldable :: ∀ f a. Foldable f => Explain a => f a -> String
 explainFoldable list = foldl explainItem "" list where
   explainItem :: String -> a -> String
   explainItem accu a = accu <> "\n    * " <> explain a -- capitalize (explain a)

--- a/src/Data/Explain.purs
+++ b/src/Data/Explain.purs
@@ -1,28 +1,67 @@
 module Data.Explain
   ( class Explain
   , explain
-  ) where
+  , class VariantExplains
+  , variantExplains
+  )
+where
 
 
-import Data.Explain (class Explain, explain)
 import Data.Foldable (foldl, class Foldable)
-import Foreign (ForeignError(TypeMismatch, ErrorAtProperty, ErrorAtIndex, ForeignError))
+import Data.List as L
+import Foreign (ForeignError(..))
+import Data.List.Types (NonEmptyList)
+import Data.Variant (Variant)
+import Data.Variant.Internal (class VariantTags, RLProxy(..), VariantCase, VariantRep(..), lookup, variantTags)
 import Prelude (show, (<>))
-import Utils.String (capitalize)
+import Type.Row as R
+import Unsafe.Coerce (unsafeCoerce)
 
 class Explain a where
   explain :: a -> String
 
-
+-------------------------------------------------------------------------------
 instance explainString :: Explain String where
   explain str = str
 
-instance explainFoldable :: (Foldable f, Explain a) => Explain (f a) where
-  explain :: forall f a. Foldable f => Explain a => f a -> String
-  explain list = foldl explainItem "" list where
-    explainItem :: String -> a -> String
-    explainItem accu a = accu <> "\n    * " <> capitalize (explain a)
+-------------------------------------------------------------------------------
+explainFoldable :: forall f a. Foldable f => Explain a => f a -> String
+explainFoldable list = foldl explainItem "" list where
+  explainItem :: String -> a -> String
+  explainItem accu a = accu <> "\n    * " <> explain a -- capitalize (explain a)
 
+instance explainNonEmptyList :: Explain a => Explain (NonEmptyList a) where
+  explain = explainFoldable
+
+instance explainArray :: Explain a => Explain (Array a) where
+  explain = explainFoldable
+
+-------------------------------------------------------------------------------
+class VariantExplains (rl ∷ R.RowList) where
+  variantExplains ∷ RLProxy rl → L.List (VariantCase → String)
+
+instance showVariantNil ∷ VariantExplains R.Nil where
+  variantExplains _ = L.Nil
+
+instance explainVariantCons ∷ (VariantExplains rs, Explain a) ⇒ VariantExplains (R.Cons sym a rs) where
+  variantExplains _ =
+    L.Cons (coerceExplain explain) (variantExplains (RLProxy ∷ RLProxy rs))
+    where
+    coerceExplain ∷ (a → String) → VariantCase → String
+    coerceExplain = unsafeCoerce
+
+instance explainVariant ∷ (R.RowToList r rl, VariantTags rl, VariantExplains rl) ⇒ Explain (Variant r) where
+  explain :: (Variant r) -> String
+  explain v1 =
+    let
+      VariantRep v = unsafeCoerce v1 ∷ VariantRep VariantCase
+      tags = variantTags (RLProxy ∷ RLProxy rl)
+      explains = variantExplains (RLProxy ∷ RLProxy rl)
+      body = lookup "explain" v.type tags explains v.value
+    in
+      body
+
+-------------------------------------------------------------------------------
 instance explainForeignError :: Explain ForeignError where
   explain :: ForeignError -> String
   explain e

--- a/src/Data/Rules.purs
+++ b/src/Data/Rules.purs
@@ -13,7 +13,7 @@ boolRule :: String -> Boolean -> Rules
 boolRule _   false = []
 boolRule str true  = [str]
 
-maybeRules :: forall a. (a -> Rules) -> Maybe a -> Rules
+maybeRules :: ∀ a. (a -> Rules) -> Maybe a -> Rules
 maybeRules _ (Nothing) = []
 maybeRules f (Just a) = f a
 

--- a/src/Github/Api/Api.purs
+++ b/src/Github/Api/Api.purs
@@ -1,10 +1,23 @@
 module Github.Api.Api
-  -- ( getRepo
-  -- , GetRepoErrors(..)
-  -- , getBranchProtection
-  -- , GetBranchProtectionErrors(..)
-  -- , getBranchProtectionSettings -- TODO: Move to a Settings
-  -- )
+  ( request
+  , AccessToken(..)
+  , authHeader
+  , acceptHeader
+  , addAccessTokenIfPresent
+  , getStatusCode
+  , parseResponse
+  , api
+  , site
+  , RequestError
+  , RequestErrorImpl
+  , requestInternalError
+  , InvalidResponse
+  , InvalidResponseImpl
+  , invalidResponse
+  , InvalidCredentials
+  , InvalidCredentialsImpl
+  , invalidCredentials
+  )
    where
 
 import Prelude
@@ -14,51 +27,61 @@ import Affjax as Affjax
 import Affjax.RequestHeader (RequestHeader(..))
 import Affjax.ResponseFormat (ResponseFormatError)
 import Affjax.StatusCode (StatusCode(..))
-import Control.Async (Async)
+import Control.Async (Async, mapExceptT', throwErrorV)
+import Control.Monad.Trans.Class (lift)
+import Data.Bifunctor (lmap)
 import Control.Monad.Cont (ContT(ContT))
 import Data.Either (Either(..))
-import Data.JSON.ParseForeign (class ParseForeign)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Effect (Effect)
-import Effect.Aff (runAff)
-import Effect.Exception (Error, error)
-import Data.Show (class Show)
----------------------------
--- REQUEST
----------------------------
+import Effect.Aff (runAff_, Aff)
+import Control.Monad.Except (ExceptT(..), except)
+import Effect.Exception (Error, message)
+import Data.Variant (Variant, inj, SProxy(..))
+import Data.Explain (class Explain, explain)
+import Data.JSON.ParseForeign (class ParseForeign, readJSON)
+import Foreign (MultipleErrors)
+import Type.Row (RowApply)
+
+-- Used to join error types together (unicode option+22C3)
+infixr 0 type RowApply as ⋃
+
+
 request
-  :: forall a
+  :: ∀ a e
   . Request a
-  -> (Either Error (Response a) -> Effect Unit)
-  -> Effect Unit
--- Run the Aff and ignore the resulting fiber
-request req outercb = runAff innercb (Affjax.request req) *> pure unit where
-  -- Simplify the outercb signature by treating ResponseFormatError as a normal Error
-  innercb :: (Either Error (Response (Either ResponseFormatError a))) -> Effect Unit
-  innercb (Left err) = outercb (Left err)
-  innercb (Right {body: (Left err)}) = outercb (Left (error "Incorrect format"))
-  innercb
-    (Right
-      { body: (Right a)
-      , status
-      , statusText
-      , headers
-      }
-    ) = outercb (Right
-              { body: a
-              , status
-              , statusText
-              , headers
-              }
-           )
+  -> Async (RequestError ⋃ e) (Response a)
+request req = asyncRequestV >>= interpretResponse
+    where
+      -- Note that Affjax has two places for error handling:
+      --   * The first is the implicit one from Aff. This error happens when there is no internet,
+      --     or there is a problem with the DNS, etc.
+      --   * The second error is explicit in the response, and it happens when the response can't
+      --     be formated acording to the type `a`, described in the Request
 
+      -- Asyncronous computation of our Response
+      aff :: Aff (Response (Either ResponseFormatError a))
+      aff = Affjax.request req
 
-requestCont
-  :: forall a
-  . Request a
-  -> Async (Either Error (Response a))
-requestCont req = ContT (\cb -> request req cb)
+      -- Convert the aff computation into a Monad Transformer closer to Async
+      asyncRequestT :: ExceptT Error (ContT Unit Effect) (Response (Either ResponseFormatError a))
+      asyncRequestT = ExceptT $ ContT $ flip runAff_ $ aff
+
+      -- Convert the computation to Async by interpreting (Aff Error) into the (Variant RequestError)
+      asyncRequestV :: Async (RequestError ⋃ e) (Response (Either ResponseFormatError a))
+      asyncRequestV = asyncRequestT `mapExceptT'` requestInternalError req
+
+      -- Once we have the response, interpret the (Either ResponseFormatError) as a (Variant RequestError)
+      interpretResponse :: Response (Either ResponseFormatError a) -> Async (RequestError ⋃ e) (Response a)
+      interpretResponse res =
+        case res.body of
+          Left formatError -> throwErrorV $ requestIncorrectFormatError req formatError
+                           -- If the value is correct, remove the Either from the Response
+          Right a          -> lift $ pure $ res {body = a}
+
+-------------------------------------------------------------------------------
+-- HEADERS
 
 -- Some methods are restricted and needs an  Access Token
 newtype AccessToken = AccessToken String
@@ -76,7 +99,6 @@ authHeader (AccessToken token) = RequestHeader "Authorization" ("Bearer " <> tok
 acceptHeader :: String -> RequestHeader
 acceptHeader negotiation = RequestHeader "Accept" negotiation
 
-
 addAccessTokenIfPresent :: Maybe AccessToken -> Array RequestHeader  -> Array RequestHeader
 addAccessTokenIfPresent Nothing            headers = headers
 addAccessTokenIfPresent (Just accessToken) headers = headers <> [authHeader accessToken]
@@ -84,9 +106,9 @@ addAccessTokenIfPresent (Just accessToken) headers = headers <> [authHeader acce
 getStatusCode :: StatusCode -> Int
 getStatusCode (StatusCode n) = n
 
----------------------------
--- API
----------------------------
+-------------------------------------------------------------------------------
+-- URLS
+
 api :: String -> String
 api url = "https://api.github.com/" <> url
 
@@ -97,7 +119,62 @@ site url = "https://www.github.com/" <> url
 -- https://developer.github.com/v3/#conditional-requests
 
 
+-------------------------------------------------------------------------------
+-- ERRORS
 
+-- | Error thrown when a affjax request cant be resolved
+type RequestError ρ = (requestError ∷ RequestErrorImpl | ρ)
+
+-- There are two reasons why the request can fail. An internal error normally represents no internet, DNS
+-- problem, etc. IncorrectFormat is when parsing the response, if it can't be formated as the request intended
+data RequestErrorImpl
+  = IncorrectFormat ResponseFormatError
+  | InternalError Error
+
+
+instance explainRequestError :: Explain RequestErrorImpl where
+  explain (IncorrectFormat formatError) = "Incorrect format"
+  explain (InternalError error) = "Internal error: " <> message error
+
+-- | Error constructors for the Variant RequestError
+requestIncorrectFormatError :: ∀ a ρ. Request a -> ResponseFormatError -> Variant (RequestError ⋃ ρ)
+requestIncorrectFormatError req formatError = inj (SProxy :: SProxy "requestError") (IncorrectFormat formatError)
+
+requestInternalError :: ∀ a ρ. Request a -> Error -> Variant (RequestError ⋃ ρ)
+requestInternalError req error = inj (SProxy :: SProxy "requestError") (InternalError error)
+
+---------------------------------------
+
+type InvalidResponse ρ = (invalidResponse ∷ InvalidResponseImpl | ρ)
+
+data InvalidResponseImpl
+  = InvalidResponseImpl MultipleErrors
+
+instance explainInvalidResponse :: Explain InvalidResponseImpl where
+  explain (InvalidResponseImpl err)  = "Github response doesn't match what we expected: " <> explain err
+
+-- | Error constructors for the Variant InvalidResponse
+invalidResponse :: ∀ ρ. MultipleErrors -> Variant (InvalidResponse ⋃ ρ)
+invalidResponse err = inj (SProxy :: SProxy "invalidResponse") (InvalidResponseImpl err)
+
+parseResponse :: ∀ a ρ. ParseForeign a => String -> Async (InvalidResponse ρ) a
+parseResponse str = except parsedJSON where
+    -- Parse the JSON and convert the error
+    parsedJSON = readJSON str # lmap invalidResponse
+
+---------------------------------------
+
+-- | This error is usually tied to error 401
+type InvalidCredentials ρ = (invalidCredentials ∷ InvalidCredentialsImpl | ρ)
+
+data InvalidCredentialsImpl = InvalidCredentialsImpl
+
+instance explainInvalidCredentials :: Explain InvalidCredentialsImpl where
+  explain InvalidCredentialsImpl  = "The access token you provided is invalid or cancelled"
+
+-- | Error constructors for the Variant InvalidCredentials
+invalidCredentials :: ∀ ρ. Variant (InvalidCredentials ⋃ ρ)
+invalidCredentials = inj (SProxy :: SProxy "invalidCredentials") InvalidCredentialsImpl
 
 
 

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,19 +2,29 @@ module Main where
 
 import Prelude
 
-import Control.Async (Async, ifItWorked, withError)
+import Control.Async (Async, runAsync)
+import Control.File (ReadJsonFileError)
 import Control.File as File
-import Control.Monad.Cont.Trans (runContT)
 import Data.Either (Either(..))
-import Data.Explain (class Explain, explain)
+import Data.Explain (explain)
+import Data.JSON.ParseForeign (class ParseForeign)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Effect (Effect)
 import Effect.Console (log)
 import Github.Api.Api (AccessToken)
-import Github.Api.Repository (Repository, GetRepoErrors, getRepo)
+import Github.Api.Repository (Repository, GetRepoError, getRepo)
 import Github.Entities (OrgName, RepoName)
 import Github.Settings.BranchProtection (BranchProtectionSettings)
+import Type.Row (RowApply)
+
+
+-- Used to join error types together (unicode option+22C3)
+infixr 0 type RowApply as ⋃
+
+-- Empty Set (unicode option+00D8)
+type Ø = ()
+
 
 newtype Config = Config
   { githubToken  :: Maybe AccessToken
@@ -25,40 +35,27 @@ newtype Config = Config
 
 derive instance newtypeConfig :: Newtype Config _
 
-readConfig :: String -> Async (Either File.ReadJsonError Config)
+derive newtype instance parseForeignConfig :: ParseForeign Config
+
+readConfig :: ∀ e. String -> Async (ReadJsonFileError e) Config
 readConfig = File.readJsonFile
 
+-- TODO: If I want to have this type of error message where I add context, I should be able to group
+-- by ConfigError, etc
+-- instance explainProgramErrors :: Explain ProgramErrors where
+--   explain :: ProgramErrors -> String
+--   explain (ConfigError err) = "There was an error while reading the configuration file: " <> explain err
+--   explain (GetRepositoryError err) = "Error fetching the repository: " <> explain err
+type ProgramErrors = (ReadJsonFileError ⋃ GetRepoError ⋃ Ø)
 
-data ProgramErrors
-  = ConfigError File.ReadJsonError
-  | GetRepositoryError GetRepoErrors
-
-
-instance explainProgramErrors :: Explain ProgramErrors where
-  explain :: ProgramErrors -> String
-  explain (ConfigError err) = "There was an error while reading the configuration file: " <> explain err
-  explain (GetRepositoryError err) = "Error fetching the repository: " <> explain err
-
-
-program :: Async (Either ProgramErrors Repository)
+program :: Async ProgramErrors Repository
 program = do
-  -- maybeConfig :: Either ProgramErrors Config
-  maybeConfig <- readConfig "./config.json" `withError` ConfigError
-  ifItWorked maybeConfig (\
-    (Config config) -> getRepo config.githubToken config.organization config.repository `withError` GetRepositoryError
-  )
+  config <- readConfig "./config.json"
+  config # (\(Config c) -> getRepo c.githubToken c.organization c.repository)
 
 
 main :: Effect Unit
-main = runContT program resultCb where
-  resultCb = (\m -> case m of
-      Left err     -> log $ "Buu: " <> explain err
-      Right result -> log $ "Yeay: " <> show result
-  )
+main = runAsync program resultCb where
+  resultCb (Left err)     = log $ "Buu: " <> explain err
+  resultCb (Right result) = log $ "Yeay: " <> show result
 
--- Testing
-readBrachProtectionSettings :: Async (Either ProgramErrors String)
-readBrachProtectionSettings = do
-  -- maybeConfig :: Either ProgramErrors Config
-  maybeConfig <- readConfig "./config.json" `withError` ConfigError
-  pure $ (\(Config config) -> explain config.branchProtection) <$> maybeConfig

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,22 +2,23 @@ module Main where
 
 import Prelude
 
-import Control.Async (Async, runAsync)
-import Control.File (ReadJsonFileError)
+import Control.Async (Async, runAsync, mapExceptT')
+import Control.File (JsonParseErrorImpl(..), ReadFileErrorImpl(..), ReadJsonFileError, _readFileError, _readFileJsonParseError)
 import Control.File as File
 import Data.Either (Either(..))
-import Data.Explain (explain)
+import Data.Explain (class Explain, explain)
 import Data.JSON.ParseForeign (class ParseForeign)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
+import Data.Variant (SProxy(..), Variant, default, inj, onMatch)
 import Effect (Effect)
 import Effect.Console (log)
+import Effect.Exception (message)
 import Github.Api.Api (AccessToken)
 import Github.Api.Repository (Repository, GetRepoError, getRepo)
 import Github.Entities (OrgName, RepoName)
 import Github.Settings.BranchProtection (BranchProtectionSettings)
 import Type.Row (RowApply)
-
 
 -- Used to join error types together (unicode option+22C3)
 infixr 0 type RowApply as ⋃
@@ -37,16 +38,38 @@ derive instance newtypeConfig :: Newtype Config _
 
 derive newtype instance parseForeignConfig :: ParseForeign Config
 
-readConfig :: ∀ e. String -> Async (ReadJsonFileError e) Config
-readConfig = File.readJsonFile
+type ReadConfigError ρ = (readConfigError ∷ ReadConfigErrorImpl ρ | ρ)
 
--- TODO: If I want to have this type of error message where I add context, I should be able to group
--- by ConfigError, etc
--- instance explainProgramErrors :: Explain ProgramErrors where
---   explain :: ProgramErrors -> String
---   explain (ConfigError err) = "There was an error while reading the configuration file: " <> explain err
---   explain (GetRepositoryError err) = "Error fetching the repository: " <> explain err
-type ProgramErrors = (ReadJsonFileError ⋃ GetRepoError ⋃ Ø)
+newtype ReadConfigErrorImpl e
+  = ReadConfigErrorImpl (Variant (ReadJsonFileError e))
+
+instance explainReadConfigError :: Explain (ReadConfigErrorImpl e) where
+  explain (ReadConfigErrorImpl err) = explain' err where
+    explain'
+      = default "Unknown problem"
+      # onMatch
+        { readFileError: \(ReadFileErrorImpl {error})
+            -> "Can't read the config file: " <> message error
+        , readFileJsonParseError: \(JsonParseErrorImpl {path, error})
+            -> "There was a problem parsing the config file '" <> path <>"':"<> explain error
+        }
+
+
+readConfigError :: ∀ ρ. Variant (ReadJsonFileError ρ) -> Variant (ReadConfigError ρ)
+readConfigError error = inj (SProxy :: SProxy "readConfigError") (ReadConfigErrorImpl error)
+
+groupByReadConfigError :: forall e. Variant (ReadJsonFileError ⋃ ReadConfigError e) -> Variant (ReadConfigError e)
+groupByReadConfigError = onMatch
+  { readFileError: readConfigError <<< inj _readFileError
+  , readFileJsonParseError: readConfigError <<< inj _readFileJsonParseError
+  } identity
+
+readConfig :: ∀ e. String -> Async (ReadConfigError e) Config
+readConfig path = File.readJsonFile path `mapExceptT'` groupByReadConfigError
+
+-------------------------------------------------------------------------------
+
+type ProgramErrors = (ReadConfigError ⋃ GetRepoError ⋃ Ø)
 
 program :: Async ProgramErrors Repository
 program = do

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -50,8 +50,8 @@ type ProgramErrors = (ReadJsonFileError ⋃ GetRepoError ⋃ Ø)
 
 program :: Async ProgramErrors Repository
 program = do
-  config <- readConfig "./config.json"
-  config # (\(Config c) -> getRepo c.githubToken c.organization c.repository)
+  Config c <- readConfig "./config.json"
+  getRepo c.githubToken c.organization c.repository
 
 
 main :: Effect Unit

--- a/src/Poc.purs
+++ b/src/Poc.purs
@@ -41,8 +41,8 @@ type ProgramErrors = (ReadJsonFileError ⋃ GetRepoError ⋃ Ø)
 
 program :: Async ProgramErrors Repository
 program = do
-  config <- readConfig "./poc-config.json"
-  config # (\(Config c) -> getRepo c.githubToken c.organization c.repository)
+  Config c <- readConfig "./poc-config.json"
+  getRepo c.githubToken c.organization c.repository
 
 
 

--- a/src/Utils/ReplHelpers.purs
+++ b/src/Utils/ReplHelpers.purs
@@ -5,28 +5,33 @@ module Utils.ReplHelpers
 where
 
 import Prelude
-import Control.Async (Async)
-import Control.Monad.Cont.Trans (runContT)
-import Effect (Effect)
-import Effect.Console (log)
+
+import Control.Async (Async, runAsync)
 import Data.Either (Either(..))
 import Data.Explain (class Explain, explain)
+import Data.Variant (Variant)
+import Effect (Effect)
+import Effect.Console (log)
 
 try
-  :: forall err ok. Explain err => Show ok
-  => Async (Either err ok)
+  :: ∀ e a
+  .  Show a
+  => Explain (Variant e)
+  => Async e a
   -> Effect Unit
-try program = runContT program resultCb where
+try program = runAsync program resultCb where
   resultCb = (\m -> case m of
-      Left err     -> log $ "Fail: " <> explain err
-      Right result -> log $ "Ok: "   <> show result
+      Left  err    -> log $ "Fail': " <> explain err
+      Right result -> log $ "Ok': "   <> show result
   )
 
+
 try'
-  :: forall err. Explain err
-  => Async (Either err String)
+  :: ∀ e
+  .  Explain (Variant e)
+  => Async e String
   -> Effect Unit
-try' program = runContT program resultCb where
+try' program = runAsync program resultCb where
   resultCb = (\m -> case m of
       Left err     -> log $ "Fail: " <> explain err
       Right result -> log $ "Ok: "   <> result

--- a/test/Data/JSON/ParseForeignSpec.purs
+++ b/test/Data/JSON/ParseForeignSpec.purs
@@ -13,7 +13,7 @@ import Test.Spec.Assertions (shouldEqual)
 
 
 -- Helper function to ease comparison
-multipleErrors :: forall a. Array ForeignError -> Either (NonEmptyList ForeignError) a
+multipleErrors :: ∀ a. Array ForeignError -> Either (NonEmptyList ForeignError) a
 multipleErrors errs = case fromFoldable errs of
   Just list -> Left list
   Nothing   -> Left $ singleton $ ForeignError "The test data needs to have at least one error"


### PR DESCRIPTION
## Description
Changed the way we handle errors by using `ExceptV` defined in the [checked-exceptions](https://pursuit.purescript.org/packages/purescript-checked-exceptions/2.0.0) library.

## Reason
Before this PR,  the `Async a` type didn't include error handling, so all the functions that may fail are represented with an `Async (Either e a)`.  This represents two major problems:

### Managing a Monad inside a Monad can be tedious
As you can see in the [main program](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-9f118d3cc59bcce279fc6619cd89d945L45), I used a `ifItWorked` function to ask after each step if the previous step worked. While doing this refactor I found out I could've probably used a `do` expression inside a `runExceptT` to simplify the code, but I couldn't make it work. The new way is a lot clearer, and transmit better the intent of the program.

### Errors are too rigid
If `e` is a `data` type, the internal constructor can't be shared between two definitions. That leads to code duplication, as you can notice in the `InternalError` type and the corresponding `explain` function in [GetRepoErrors](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-04debc34bb94749fe81919c0b70a48fbL73) and [GetBranchProtectionErrors](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-5672f0c95ca11c65776ae652b135c562L99). The error is basically the same, but because they are in different constructs, they can't be shared.

This mean that you can't express in the type system that you've handled an error without creating a new `data` type (with all the code duplication that it entails). For example, in the [getBranchProtectionSettings](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-78bffca19be7145bc4105d3db6c15adfL34) function, the `interpretResponse` helper converts a `GetBranchNotProtected` Api Error (404 with a special message) into an [BranchNotProtected](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-78bffca19be7145bc4105d3db6c15adfL81) value. The function signature states that it can fail with `GetBranchProtectionErrors`, which is "false" because we already handled `GetBranchNotProtected`. By using `ExceptV` we can [model that](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-78bffca19be7145bc4105d3db6c15adfR30) correctly.

## Changes
In order to do this, we modified [Async e a](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-66652af2d08a7b33c701ba4e360cddf2R47) to be a  *[monad transformer](https://github.com/paf31/purescript-book/blob/master/text/chapter11.md)* that combines the effects of error handling with [variants](https://pursuit.purescript.org/packages/purescript-variant/5.0.0) `ExceptV` and continuation/asynchronicity with [ContT](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.Cont.Trans#t:ContT). The variant part is what allow us to manipulate our errors as an `open set`, and the monad transformer is what enable us the clear syntax of managing different effects at once.

```purescript
type ProgramErrors = (ReadConfigError ⋃ GetRepoError ⋃ Ø)

program :: Async ProgramErrors Repository
program = do
  Config c <- readConfig "./config.json"
  getRepo c.githubToken c.organization c.repository
```

## Notes
Variants are way more flexible than `data` types but they are harder to manipulate. It took me some time,  and with a lot of help of [@natefaubion](https://twitter.com/natefaubion) on the FP channel to [group an error](https://github.com/hrajchert/gh-repo-sync/compare/refactor-asyncv?diff=split&expand=1#diff-9f118d3cc59bcce279fc6619cd89d945R67) to provide better context at the time that we explain it.

I'm still not sure why `ReadConfigErrorImpl` must hold an open set (which later on requires a `default` to be exhaustive) or why I need `ReadConfigError` on the left side of this expression, which is not commutative

```purescript
-- This works
groupByReadConfigError :: ∀ e. Variant (ReadJsonFileError ⋃ ReadConfigError ⋃ e) -> Variant (ReadConfigError ⋃ e)

-- This doesn't
groupByReadConfigError :: ∀ e. Variant (ReadConfigError ⋃ ReadJsonFileError ⋃ e) -> Variant (ReadConfigError ⋃ e)
```